### PR TITLE
Use quanteda 1.0-compatible tokens() call

### DIFF
--- a/R/make_lemma_dictionary.R
+++ b/R/make_lemma_dictionary.R
@@ -29,7 +29,7 @@
 make_lemma_dictionary <- function(..., engine = 'hunspell', path = NULL) {
 
     lemma <- token <- NULL
-    tokens <- na_omit(unique(unlist(quanteda::tokenize(tolower(unlist(...))))))
+    tokens <- na_omit(unique(unlist(quanteda::tokens(tolower(unlist(...))))))
 
     switch(engine,
         treetagger = {


### PR DESCRIPTION
For the upcoming **quanteda** 1.0 release, we have killed off the deprecated `tokenize()` functions. To make **textstem** compatible, I simply changed the `tokenize()` call to `tokens()`.